### PR TITLE
Add tracelane to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Inspired by the [awesome](https://awesome.re) list. Feel free to improve this li
 - [OCR service for Appium Native Apps](https://github.com/wswebcreation/wdio-ocr-service) - Run Tesseract OCR for Appium Native App tests.
 - [Auto-detect missing imports w/eslint](https://github.com/jamesmortensen/wdio-eslinter-service) - Automatically run eslint checks prior to executing tests.
 - [wopee.wdio](https://github.com/autonomous-testing/wopee.wdio) - Visual regression testing service by Wopee.io with autonomous test maintenance and AI-powered healing.
+- [tracelane](https://github.com/Cubenest/rrweb-stack) - Records failed end-to-end tests as self-contained, offline-replayable HTML reports with session replay, console and failed-network panels. No backend.
 
 ### Reporters
 


### PR DESCRIPTION
Adds [tracelane](https://github.com/Cubenest/rrweb-stack), an open-source service that ships a single self-contained, offline HTML replay (rrweb capture + console + failed-network) on test failure — no SaaS, no backend. You attach the resulting `.html` file to a CI run or a ticket and open it in any browser.

- Apache-2.0
- npm: `@tracelane/wdio`
- Docs / live demo report: https://tracelane.cubenest.in

Added to the bottom of `### Services` per the contributing rules (GitHub repo link, not npm; appended rather than sorted).
